### PR TITLE
Fix for "keep-missed should be to TRUE by default"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+CHANGELOG
+========
+
+# 1.0.4 (24.09.2018)
+- [--keep-missed flag replaced by --remove-missed](https://github.com/haftahave/serverless-ses-template/pull/2) \
+   Plugin does not remove templates those are not present in your configuration file by default.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Run `sls ses-template deploy` in order to sync your email templates.
 
 Optional CLI options:
 ```
---remove-missed -r  Set this flag in order to remove templates thouse are not present in your configuration file. [OPTIONAL]
+--remove-missed -r  Set this flag in order to remove templates those are not present in your configuration file. [OPTIONAL]
 --stage         -s  The stage used to populate your templates. Default: the first stage found in your project. [OPTIONAL]
 --region        -r  The region used to populate your templates. Default: the first region for the first stage found. [OPTIONAL]
 --alias         -a  Template alias, works only with sesTemplatesAddStageAlias option enabled. [OPTIONAL]

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Run `sls ses-template deploy` in order to sync your email templates.
 
 Optional CLI options:
 ```
---keep-missed   -k  Set this flag in order to keep templates thouse are not present in your configuration file. [OPTIONAL]
+--remove-missed -r  Set this flag in order to remove templates thouse are not present in your configuration file. [OPTIONAL]
 --stage         -s  The stage used to populate your templates. Default: the first stage found in your project. [OPTIONAL]
 --region        -r  The region used to populate your templates. Default: the first region for the first stage found. [OPTIONAL]
 --alias         -a  Template alias, works only with sesTemplatesAddStageAlias option enabled. [OPTIONAL]

--- a/index.js
+++ b/index.js
@@ -36,9 +36,9 @@ class ServerlessSesTemplate {
                             'syncTemplates',
                         ],
                         options: {
-                            'keep-missed': {
-                                usage: 'Set this flag in order to keep missed templates (e.g. "--keep-missed")',
-                                shortcut: 's',
+                            'remove-missed': {
+                                usage: 'Set this flag in order to remove missed templates. (e.g. "--remove-missed")',
+                                shortcut: 'r',
                                 required: false,
                             },
                         },
@@ -89,8 +89,7 @@ class ServerlessSesTemplate {
      */
     initOptions() {
         this.region = this.options.region || this.serverless.service.provider.region;
-
-        this.keepMissed = this.options['keep-missed'] !== undefined;
+        this.removeMissed = this.options['remove-missed'] !== undefined;
         this.stage = this.options.stage || this.serverless.service.provider.stage;
         this.alias = this.options.alias || this.serverless.service.provider.alias || 'production';
     }
@@ -145,7 +144,7 @@ class ServerlessSesTemplate {
             templateConfig => this.addStageAliasToTemplateName(templateConfig.name),
         );
 
-        const templatesToRemove = !this.keepMissed
+        const templatesToRemove = this.removeMissed
             ? currentTemplates.filter(templateName => !templatesToSync.includes(templateName)
                 && this.isTemplateFromCurrentStageAlias(templateName))
             : [];

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,19 +179,33 @@
       }
     },
     "@sinonjs/formatio": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.0.0.tgz",
+      "integrity": "sha512-vdjoYLDptCgvtJs57ULshak3iJe4NW3sJ3g36xVDGff5AE8P30S6A093EIEPjdi2noGhfuNOEkbxt3J3awFW1w==",
       "dev": true,
       "requires": {
-        "samsam": "1.3.0"
+        "@sinonjs/samsam": "2.1.0"
+      },
+      "dependencies": {
+        "@sinonjs/samsam": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.0.tgz",
+          "integrity": "sha512-5x2kFgJYupaF1ns/RmharQ90lQkd2ELS8A9X0ymkAAdemYHGtI2KiUHG8nX2WU0T1qgnOU5YMqnBM2V7NUanNw==",
+          "dev": true,
+          "requires": {
+            "array-from": "^2.1.1"
+          }
+        }
       }
     },
     "@sinonjs/samsam": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.0.0.tgz",
-      "integrity": "sha512-D7VxhADdZbDJ0HjUTMnSQ5xIGb4H2yWpg8k9Sf1T08zfFiQYlaxM8LZydpR4FQ2E6LZJX8IlabNZ5io4vdChwg==",
-      "dev": true
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.1.tgz",
+      "integrity": "sha512-7oX6PXMulvdN37h88dvlvRyu61GYZau40fL4wEZvPEHvrjpJc3lDv6xDM5n4Z0StufUVB5nDvVZUM+jZHdMOOQ==",
+      "dev": true,
+      "requires": {
+        "array-from": "^2.1.1"
+      }
     },
     "acorn": {
       "version": "5.7.3",
@@ -209,9 +223,9 @@
       }
     },
     "ajv": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.3.tgz",
-      "integrity": "sha512-LqZ9wY+fx3UMiiPd741yB2pj3hhil+hQc8taf4o2QGRFpWgZ2V5C8HA165DY9sS3fJwsk7uT7ZlFEyC3Ig3lLg==",
+      "version": "6.5.4",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.4.tgz",
+      "integrity": "sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -265,6 +279,12 @@
         "ast-types-flow": "0.0.7",
         "commander": "^2.11.0"
       }
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+      "dev": true
     },
     "array-includes": {
       "version": "3.0.3",
@@ -580,9 +600,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.5.0.tgz",
-      "integrity": "sha512-m+az4vYehIJgl1Z0gb25KnFXeqQRdNreYsei1jdvkd9bB+UNQD3fsuiC2AWSQ56P+/t++kFSINZXFbfai+krOw==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.6.0.tgz",
+      "integrity": "sha512-/eVYs9VVVboX286mBK7bbKnO1yamUy2UCRjiY6MryhQL2PaaXCExsCQ2aO83OeYRhU2eCU/FMFP+tVMoOrzNrA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.0.0",
@@ -1326,9 +1346,9 @@
       "dev": true
     },
     "lolex": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.4.tgz",
-      "integrity": "sha512-Gh6Vffq/piTeHwunLNFR1jFVaqlwK9GMNUxFcsO1cwHyvbRKHwX8UDkxmrDnbcPdHNmpv7z2kxtkkSx5xkNpMw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+      "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
       "dev": true
     },
     "loose-envify": {
@@ -1445,12 +1465,12 @@
       "dev": true
     },
     "nise": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.4.tgz",
-      "integrity": "sha512-pxE0c9PzgrUTyhfv5p+5eMIdfU2bLEsq8VQEuE0kxM4zP7SujSar7rk9wpI2F7RyyCEvLyj5O7Is3RER5F36Fg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.5.tgz",
+      "integrity": "sha512-OHRVvdxKgwZELf2DTgsJEIA4MOq8XWvpSUzoOXyxJ2mY0mMENWC66+70AShLR2z05B1dzrzWlUQJmJERlOUpZw==",
       "dev": true,
       "requires": {
-        "@sinonjs/formatio": "^2.0.0",
+        "@sinonjs/formatio": "3.0.0",
         "just-extend": "^3.0.0",
         "lolex": "^2.3.2",
         "path-to-regexp": "^1.7.0",
@@ -3092,12 +3112,6 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "samsam": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
-      "dev": true
-    },
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
@@ -3126,18 +3140,18 @@
       "dev": true
     },
     "sinon": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.2.0.tgz",
-      "integrity": "sha512-gLFZz5UYvOhYzQ+DBzw/OCkmWaLAHlAyQiE2wxUOmAGVdasP9Yw93E+OwZ0UuhW3ReMu1FKniuNsL6VukvC77w==",
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-6.3.4.tgz",
+      "integrity": "sha512-NIaR56Z1mefuRBXYrf4otqBxkWiKveX+fvqs3HzFq2b07HcgpkMgIwmQM/owNjNFAHkx0kJXW+Q0mDthiuslXw==",
       "dev": true,
       "requires": {
         "@sinonjs/commons": "^1.0.2",
-        "@sinonjs/formatio": "^2.0.0",
-        "@sinonjs/samsam": "^2.0.0",
+        "@sinonjs/formatio": "^3.0.0",
+        "@sinonjs/samsam": "^2.1.1",
         "diff": "^3.5.0",
         "lodash.get": "^4.4.2",
-        "lolex": "^2.7.2",
-        "nise": "^1.4.4",
+        "lolex": "^2.7.4",
+        "nise": "^1.4.5",
         "supports-color": "^5.5.0",
         "type-detect": "^4.0.8"
       }
@@ -3263,7 +3277,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "devDependencies": {
     "chai": "^4.1.2",
-    "eslint": "^5.5.0",
+    "eslint": "^5.6.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-filenames": "^1.3.2",
@@ -35,7 +35,7 @@
     "eslint-plugin-react": "^7.11.1",
     "mocha": "^5.2.0",
     "nyc": "^13.0.1",
-    "sinon": "^6.2.0"
+    "sinon": "^6.3.4"
   },
   "engines": {
     "node": ">= 8.10.0",


### PR DESCRIPTION
Fixes https://github.com/haftahave/serverless-ses-template/issues/1

- plugin does not remove templates those are not present in your configuration file by default
- `--keep-missed` flag replaced by `--remove-missed`
- `CHANGELOG.md` file added
