### PR TITLE
feat: Do not add alias to template name if undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,18 @@
 CHANGELOG
 ========
 
-# 1.1.0 (22.02.2018)
+# 1.2.0 (27.02.2019)
+- [Do not add alias to template names if alias plugin isn't used](https://github.com/haftahave/serverless-ses-template/pull/11)
+
+# 1.1.0 (22.02.2019)
 - [Custom region parameter + ability to filter templates for list function](https://github.com/haftahave/serverless-ses-template/pull/9) \
     see details in pull request description
-# 1.0.7 (16.02.2018)
-- [Ability to list email templates](https://github.com/haftahave/serverless-ses-template/pull/7) 
 
-# 1.0.6 (17.01.2018)
-- [Fixed Promise.all not actually waiting on the array of arrays](https://github.com/haftahave/serverless-ses-template/pull/6) 
+# 1.0.7 (16.02.2019)
+- [Ability to list email templates](https://github.com/haftahave/serverless-ses-template/pull/7)
+
+# 1.0.6 (17.01.2019)
+- [Fixed Promise.all not actually waiting on the array of arrays](https://github.com/haftahave/serverless-ses-template/pull/6)
 
 # 1.0.5 (24.09.2018)
 - [Remove command shortcuts](https://github.com/haftahave/serverless-ses-template/pull/4) \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A serverless plugin that allows automatically creating, updating and removing AW
 **:zap: Features**
 
 - Allows declaring email templates that will be synced in pre-deploy phase
-- Allows you to add stage and alias to template names while sync (supports [serverless-aws-alias](https://github.com/HyperBrain/serverless-aws-alias) plugin)
+- Allows you to optionally add stage to template names while syncing
+  - Will also add alias, if specified (supports [serverless-aws-alias](https://github.com/HyperBrain/serverless-aws-alias) plugin)
 - Allows you to list and delete SES template by specified name
 ---
 
@@ -30,7 +31,7 @@ plugins:
   - '@haftahave/serverless-ses-template'
 
 custom:
-  sesTemplatesAddStageAlias: true                          # Specifies whether to add stage and alias to template name (default false)
+  sesTemplatesAddStageAlias: true                          # Specifies whether to add stage and alias (if present) to template name (default false)
   sesTemplatesConfigFile: './custom-config-file/path.js'   # Config file path (default './ses-email-templates/index.js')
   sesTemplatesRegion: 'us-west-2'                          # Specifies AWS region for SES templates
 ```

--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ class ServerlessSesTemplate {
 
         this.region = this.options.sesTemplatesRegion || sesTemplatesRegion || this.options.region || region;
         this.stage = this.options.stage || stage;
-        this.alias = this.options.alias || alias || 'production';
+        this.alias = this.options.alias || alias;
 
         this.removeMissed = commands.includes('deploy') ? this.options.removeMissed !== undefined : false;
         this.filter = commands.includes('list') ? (this.options.filter || '') : '';
@@ -192,7 +192,8 @@ class ServerlessSesTemplate {
      * @returns {string}
      */
     addStageAliasToTemplateName(templateName) {
-        return this.addStageAlias ? `${templateName}_${this.stage}_${this.alias}` : templateName;
+        const aliasSuffix = this.alias ? `_${this.alias}` : '';
+        return this.addStageAlias ? `${templateName}_${this.stage}${aliasSuffix}` : templateName;
     }
 
     /**
@@ -200,7 +201,8 @@ class ServerlessSesTemplate {
      * @returns {boolean}
      */
     isTemplateFromCurrentStageAlias(templateName) {
-        return this.addStageAlias ? String(templateName).endsWith(`_${this.stage}_${this.alias}`) : true;
+        const aliasSuffix = this.alias ? `_${this.alias}` : '';
+        return this.addStageAlias ? String(templateName).endsWith(`_${this.stage}${aliasSuffix}`) : true;
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "Sergii Kovalev <enasik@gmail.com> (https://github.com/Enase)"
   ],
   "contributors": [
-    "Arseny Yankovsky (https://github.com/ArsenyYankovsky)"
+    "Arseny Yankovsky (https://github.com/ArsenyYankovsky)",
+    "Mike Cousins <mike@cousins.io> (https://mike.cousins.io)"
   ],
   "dependencies": {
     "cli-table": "^0.3.1"

--- a/tests/index.js
+++ b/tests/index.js
@@ -347,6 +347,56 @@ describe('The `ses-template` plugin', () => {
         });
     });
 
+    describe('Fresh deploy with stage but no alias', () => {
+        let serverless;
+        let pluginInstance;
+        const requestStub = sinon.stub();
+        requestStub.onCall(0).resolves({ TemplatesMetadata: [{ Name: 'template-id' }] });
+        requestStub.onCall(1).resolves();
+        const providerSpy = sinon.spy(() => ({
+            request: requestStub,
+        }));
+        before(() => {
+            serverless = mockServerless('deploy', defaultService, providerSpy);
+            serverless.service.provider.alias = undefined;
+            serverless.service.custom.sesTemplatesAddStageAlias = true;
+            pluginInstance = new ServerlessSesTemplate(serverless);
+        });
+        describe('When the `ses-template:deploy:syncTemplates` hook is executed', () => {
+            before(() => {
+                pluginInstance.hooks['ses-template:deploy:syncTemplates']();
+            });
+            it('Provider does requests to AWS SES', () => {
+                expect(requestStub.callCount).to.be.equal(2);
+            });
+            it('Loads templates from SES executes', () => {
+                expect(requestStub.getCall(0).args[0]).to.be.equal('SES');
+                expect(requestStub.getCall(0).args[1]).to.be.equal('listTemplates');
+                expect(requestStub.getCall(0).args[2]).to.be.deep.equal({
+                    MaxItems: 10,
+                    NextToken: undefined,
+                });
+                expect(requestStub.getCall(0).args[3]).to.be.deep.equal({ stage: 'dev', region: 'us-west-2' });
+            });
+            it('Creates template resource', () => {
+                expect(requestStub.getCall(1).args[0]).to.be.equal('SES');
+                expect(requestStub.getCall(1).args[1]).to.be.equal('createTemplate');
+                expect(requestStub.getCall(1).args[2]).to.be.deep.equal({
+                    Template: {
+                        TemplateName: 'example_dev',
+                        SubjectPart: 'example',
+                        HtmlPart: '<div>Hello world!</div>\n',
+                        TextPart: 'Hello world!\n',
+                    },
+                });
+                expect(requestStub.getCall(1).args[3]).to.be.deep.equal({ stage: 'dev', region: 'us-west-2' });
+            });
+            it('Logs messages', () => {
+                expect(serverless.cli.log.callCount).to.equal(3);
+            });
+        });
+    });
+
     describe('Delete template with correct values', () => {
         let serverless;
         let pluginInstance;


### PR DESCRIPTION
This PR implements the change requested in #10. If a user of this plugin is not also a user of the `serverless-alias-plugin`, it feels unexpected to add an `alias` suffix to template names.

BREAKING CHANGE: "_production" is no longer added to template names when `custom.sesTemplatesAddStageAlias` is set to true but `provider.alias` is unset, which may break clients that rely on this default

Closes #10